### PR TITLE
destory时增加必要的unRegister

### DIFF
--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatLifecycle.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatLifecycle.java
@@ -45,6 +45,11 @@ class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLi
         applicationContext.registerReceiver(this, new IntentFilter(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
     }
 
+    public void unRegisterReceiver(Context applicationContext) {
+        ((Application) applicationContext).unregisterActivityLifecycleCallbacks(this);
+        applicationContext.unregisterReceiver(this);
+    }
+
     public static void setResumedListener(ResumedListener resumedListener) {
         sResumedListener = resumedListener;
     }

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatWindow.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatWindow.java
@@ -51,7 +51,22 @@ public class FloatWindow {
             return;
         }
         mFloatWindowMap.get(tag).dismiss();
+        mFloatWindowMap.get(tag).destory();
         mFloatWindowMap.remove(tag);
+    }
+    
+    public static void destroyAll() {
+        if (mFloatWindowMap == null) return;
+        for (IFloatWindow iFloatWindow : mFloatWindowMap.values()) {
+            try {
+                iFloatWindow.dismiss();
+                iFloatWindow.destory();
+                mFloatWindowMap.remove(iFloatWindow);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        mFloatWindowMap = null;
     }
 
     public static class B {

--- a/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindow.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindow.java
@@ -29,4 +29,6 @@ public abstract class IFloatWindow {
     public abstract View getView();
 
     abstract void dismiss();
+
+    public abstract void destory();
 }

--- a/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
@@ -77,6 +77,12 @@ public class IFloatWindowImpl extends IFloatWindow {
             }
         });
     }
+    
+    @Override
+    public void destory() {
+        if (mFloatLifecycle == null) return;
+        mFloatLifecycle.unRegisterReceiver(mB.mApplicationContext);
+    }
 
     @Override
     public void show() {


### PR DESCRIPTION
之前destory只是仅仅做了dismiss的操作，不符合销毁的含义，而且异常情况也可能destory了还会显示（registerActivityLifecycleCallbacks），所以在destory的时候unRegister还是有必要的。多谢