### PR TITLE
 分离生命周期和创建浮动框，需要在Application中注册生命周期。

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,14 @@ setMoveStyle 方法可设置动画效果，只在 MoveType.slide 或 MoveType.ba
 
 **更新日志**
 --
+**v1.0.10**
 
+ 分离生命周期和创建浮动框，需要在Application中注册生命周期。
+ 这样就可以在用到浮动框的地方才去创建浮动框。
+ 解决必须在Application中创建浮动框，否则会出问题的bug。
+ 
+ 在Applicaion中先注册生命周期：FloatWindow.initLifecycle(this);
+ 
 **v1.0.9**
 
  修复拖动点击事件冲突

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatLifecycle.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatLifecycle.java
@@ -8,7 +8,9 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
-import android.widget.Toast;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Created by yhao on 17-12-1.
@@ -17,29 +19,30 @@ import android.widget.Toast;
  * 1.startCount计数，针对back到桌面可以及时隐藏
  * 2.监听home键，从而及时隐藏
  * 3.resumeCount计时，针对一些只执行onPause不执行onStop的奇葩情况
+ *
+ * modify by bond on 2019-08-29 解耦和{@link IFloatWindowImpl}
  */
 
-class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLifecycleCallbacks {
+public class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLifecycleCallbacks {
 
     private static final String SYSTEM_DIALOG_REASON_KEY = "reason";
     private static final String SYSTEM_DIALOG_REASON_HOME_KEY = "homekey";
     private static final long delay = 300;
     private Handler mHandler;
-    private Class[] activities;
-    private boolean showFlag;
     private int startCount;
     private int resumeCount;
     private boolean appBackground;
-    private LifecycleListener mLifecycleListener;
     private static ResumedListener sResumedListener;
     private static int num = 0;
 
+    private static Set<IFloatWindowImpl> set = new HashSet<>();
 
-    FloatLifecycle(Context applicationContext, boolean showFlag, Class[] activities, LifecycleListener lifecycleListener) {
-        this.showFlag = showFlag;
-        this.activities = activities;
+    public static void register(IFloatWindowImpl floatWindow){
+        set.add(floatWindow);
+    }
+
+    public FloatLifecycle(Context applicationContext) {
         num++;
-        mLifecycleListener = lifecycleListener;
         mHandler = new Handler();
         ((Application) applicationContext).registerActivityLifecycleCallbacks(this);
         applicationContext.registerReceiver(this, new IntentFilter(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
@@ -49,18 +52,21 @@ class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLi
         sResumedListener = resumedListener;
     }
 
-    private boolean needShow(Activity activity) {
-        if (activities == null) {
-            return true;
-        }
-        for (Class a : activities) {
-            if (a.isInstance(activity)) {
-                return showFlag;
+    public void showOrHide(Activity activity){
+        for(IFloatWindowImpl window : set){
+            if(window.needShow(activity)){
+                window.show();
+            } else {
+                window.hide();
             }
         }
-        return !showFlag;
     }
 
+    public void onBackToDesktop(){
+        for(IFloatWindowImpl window : set){
+            window.onBackToDesktop();
+        }
+    }
 
     @Override
     public void onActivityResumed(Activity activity) {
@@ -72,11 +78,7 @@ class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLi
             }
         }
         resumeCount++;
-        if (needShow(activity)) {
-            mLifecycleListener.onShow();
-        } else {
-            mLifecycleListener.onHide();
-        }
+        showOrHide(activity);
         if (appBackground) {
             appBackground = false;
         }
@@ -90,11 +92,10 @@ class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLi
             public void run() {
                 if (resumeCount == 0) {
                     appBackground = true;
-                    mLifecycleListener.onBackToDesktop();
+                    onBackToDesktop();
                 }
             }
         }, delay);
-
     }
 
     @Override
@@ -107,7 +108,7 @@ class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLi
     public void onActivityStopped(Activity activity) {
         startCount--;
         if (startCount == 0) {
-            mLifecycleListener.onBackToDesktop();
+            onBackToDesktop();
         }
     }
 
@@ -117,7 +118,7 @@ class FloatLifecycle extends BroadcastReceiver implements Application.ActivityLi
         if (action != null && action.equals(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)) {
             String reason = intent.getStringExtra(SYSTEM_DIALOG_REASON_KEY);
             if (SYSTEM_DIALOG_REASON_HOME_KEY.equals(reason)) {
-                mLifecycleListener.onBackToDesktop();
+                onBackToDesktop();
             }
         }
     }

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatLifecycle.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatLifecycle.java
@@ -40,6 +40,10 @@ public class FloatLifecycle extends BroadcastReceiver implements Application.Act
     public static void register(IFloatWindowImpl floatWindow){
         set.add(floatWindow);
     }
+    
+    public static void unregister(IFloatWindowImpl floatWindow){
+        set.remove(floatWindow);
+    }
 
     public FloatLifecycle(Context applicationContext) {
         num++;

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatWindow.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatWindow.java
@@ -1,6 +1,7 @@
 package com.yhao.floatwindow;
 
 import android.animation.TimeInterpolator;
+import android.app.Application;
 import android.content.Context;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.MainThread;
@@ -16,9 +17,17 @@ import java.util.Map;
 /**
  * Created by yhao on 2017/12/22.
  * https://github.com/yhaolpz
+ *
+ * modify by bond on 2019-08-29 分离生命周期注册和浮动框创建逻辑。这样就可以在用到浮动框的地方才去创建浮动框。
+ * 解决必须在Application中创建浮动框，否则会出问题的bug.
  */
 
 public class FloatWindow {
+    static FloatLifecycle floatLifecycle;
+
+    public static void initLifecycle(Application application){
+        floatLifecycle = new FloatLifecycle(application);
+    }
 
     private FloatWindow() {
 

--- a/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
@@ -97,6 +97,7 @@ public class IFloatWindowImpl extends IFloatWindow {
         if (mB.mViewStateListener != null) {
             mB.mViewStateListener.onDismiss();
         }
+        FloatLifecycle.unregister(this);
     }
 
     @Override

--- a/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
@@ -7,6 +7,7 @@ import android.animation.PropertyValuesHolder;
 import android.animation.TimeInterpolator;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
@@ -19,11 +20,8 @@ import android.view.animation.DecelerateInterpolator;
  */
 
 public class IFloatWindowImpl extends IFloatWindow {
-
-
     private FloatWindow.B mB;
     private FloatView mFloatView;
-    private FloatLifecycle mFloatLifecycle;
     private boolean isShow;
     private boolean once = true;
     private ValueAnimator mAnimator;
@@ -34,7 +32,6 @@ public class IFloatWindowImpl extends IFloatWindow {
     private float upY;
     private boolean mClick = false;
     private int mSlop;
-
 
     private IFloatWindowImpl() {
 
@@ -55,27 +52,7 @@ public class IFloatWindowImpl extends IFloatWindow {
         mFloatView.setSize(mB.mWidth, mB.mHeight);
         mFloatView.setGravity(mB.gravity, mB.xOffset, mB.yOffset);
         mFloatView.setView(mB.mView);
-        mFloatLifecycle = new FloatLifecycle(mB.mApplicationContext, mB.mShow, mB.mActivities, new LifecycleListener() {
-            @Override
-            public void onShow() {
-                show();
-            }
-
-            @Override
-            public void onHide() {
-                hide();
-            }
-
-            @Override
-            public void onBackToDesktop() {
-                if (!mB.mDesktopShow) {
-                    hide();
-                }
-                if (mB.mViewStateListener != null) {
-                    mB.mViewStateListener.onBackToDesktop();
-                }
-            }
-        });
+        FloatLifecycle.register(this);
     }
 
     @Override
@@ -299,4 +276,24 @@ public class IFloatWindowImpl extends IFloatWindow {
         }
     }
 
+    public boolean needShow(Activity activity) {
+        if (mB.mActivities == null) {
+            return true;
+        }
+        for (Class a : mB.mActivities) {
+            if (a.isInstance(activity)) {
+                return mB.mShow;
+            }
+        }
+        return !mB.mShow;
+    }
+
+    public void onBackToDesktop() {
+        if (!mB.mDesktopShow) {
+            hide();
+        }
+        if (mB.mViewStateListener != null) {
+            mB.mViewStateListener.onBackToDesktop();
+        }
+    }
 }

--- a/sample/src/main/java/com/example/yhao/floatwindow/BaseApplication.java
+++ b/sample/src/main/java/com/example/yhao/floatwindow/BaseApplication.java
@@ -32,6 +32,8 @@ public class BaseApplication extends Application {
         ImageView imageView = new ImageView(getApplicationContext());
         imageView.setImageResource(R.drawable.icon);
 
+        // 分离生命周期和创建浮动框
+        FloatWindow.initLifecycle(this);
         FloatWindow
                 .with(getApplicationContext())
                 .setView(imageView)


### PR DESCRIPTION
 这样就可以在用到浮动框的地方才去创建浮动框。
 解决必须在Application中创建浮动框，否则会出问题的bug。
 在Applicaion中先注册生命周期：FloatWindow.initLifecycle(this);

西瓜智选股有采用这个库，接入时我们是在Activity中取创建浮层，发现实现不了文档所说的指定页面显示浮层，经过调试发现在Activity中创建浮层会出现生命周期问题，所有我把生命周期注册的代码分离了下，改动非常小。