### PR TITLE
新增 updateFlags 方法，可修复悬浮窗中的edittext无法弹出输入法

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ setMoveStyle 方法可设置动画效果，只在 MoveType.slide 或 MoveType.ba
 
 本人已尽量去兼容更多机型，但经济有限，如果你想帮助此库，提 Issues 标出当前版本不适配的机型即可，感谢~
 
+### 新增功能
+1, setFlags (可修复悬浮窗 TextEdit 不可弹出输入法) 
+```java
+// 使悬浮窗获取焦点
+FloatWindow.get().updateFlags(WindowManager.LayoutParams.FLAG_LAYOUT_INSET_DECOR);
+
+// 使悬浮窗失去焦点
+FloatWindow.get().updateFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+
+```
 
 **更新日志**
 --

--- a/floatwindow/build.gradle
+++ b/floatwindow/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
     }
 
@@ -25,14 +25,14 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.+'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     testCompile 'junit:junit:4.12'
 }
 
 // JitPack Maven
-apply plugin: 'com.github.dcendents.android-maven'
+// apply plugin: 'com.github.dcendents.android-maven'
 // Your Group
-group='com.github.yhaolpz'
+// group='com.github.yhaolpz'

--- a/floatwindow/src/androidTest/java/com/example/fixedfloatwindow/ExampleInstrumentedTest.java
+++ b/floatwindow/src/androidTest/java/com/example/fixedfloatwindow/ExampleInstrumentedTest.java
@@ -1,8 +1,9 @@
 package com.example.fixedfloatwindow;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatActivity.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatActivity.java
@@ -7,7 +7,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatPhone.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatPhone.java
@@ -52,6 +52,11 @@ class FloatPhone extends FloatView {
         mLayoutParams.y = mY = yOffset;
     }
 
+    @Override
+    void setFlags(int flags) {
+        super.setFlags(flags);
+        mLayoutParams.flags = flags;
+    }
 
     @Override
     public void init() {
@@ -140,6 +145,13 @@ class FloatPhone extends FloatView {
     void updateY(int y) {
         if (isRemove) return;
         mLayoutParams.y = mY = y;
+        mWindowManager.updateViewLayout(mView, mLayoutParams);
+    }
+
+    @Override
+    void updateFlags(int flags) {
+        if (isRemove) return;
+        mLayoutParams.flags = flags;
         mWindowManager.updateViewLayout(mView, mLayoutParams);
     }
 

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatView.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatView.java
@@ -28,6 +28,10 @@ abstract class FloatView {
     void updateY(int y) {
     }
 
+    void setFlags(int flags) {}
+
+    void updateFlags(int flags) {}
+
     int getX() {
         return 0;
     }

--- a/floatwindow/src/main/java/com/yhao/floatwindow/FloatWindow.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/FloatWindow.java
@@ -2,13 +2,14 @@ package com.yhao.floatwindow;
 
 import android.animation.TimeInterpolator;
 import android.content.Context;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.MainThread;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +62,7 @@ public class FloatWindow {
         int mWidth = ViewGroup.LayoutParams.WRAP_CONTENT;
         int mHeight = ViewGroup.LayoutParams.WRAP_CONTENT;
         int gravity = Gravity.TOP | Gravity.START;
+        int mFlags;
         int xOffset;
         int yOffset;
         boolean mShow = true;
@@ -107,6 +109,11 @@ public class FloatWindow {
             mWidth = (int) ((screenType == Screen.width ?
                     Util.getScreenWidth(mApplicationContext) :
                     Util.getScreenHeight(mApplicationContext)) * ratio);
+            return this;
+        }
+
+        public B setFlags(int flags) {
+            mFlags = flags;
             return this;
         }
 

--- a/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindow.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindow.java
@@ -26,6 +26,8 @@ public abstract class IFloatWindow {
 
     public abstract void updateY(@Screen.screenType int screenType,float ratio);
 
+    public abstract void updateFlags(int flags);
+
     public abstract View getView();
 
     abstract void dismiss();

--- a/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/IFloatWindowImpl.java
@@ -55,6 +55,7 @@ public class IFloatWindowImpl extends IFloatWindow {
         mFloatView.setSize(mB.mWidth, mB.mHeight);
         mFloatView.setGravity(mB.gravity, mB.xOffset, mB.yOffset);
         mFloatView.setView(mB.mView);
+        mFloatView.setFlags(mB.mFlags);
         mFloatLifecycle = new FloatLifecycle(mB.mApplicationContext, mB.mShow, mB.mActivities, new LifecycleListener() {
             @Override
             public void onShow() {
@@ -110,6 +111,7 @@ public class IFloatWindowImpl extends IFloatWindow {
 
     @Override
     public boolean isShowing() {
+        if(mB == null) return false;
         return isShow;
     }
 
@@ -154,6 +156,11 @@ public class IFloatWindowImpl extends IFloatWindow {
                 Util.getScreenHeight(mB.mApplicationContext)) * ratio);
         mFloatView.updateY(mB.yOffset);
 
+    }
+
+    @Override
+    public void updateFlags(int flags) {
+        mFloatView.updateFlags(flags);
     }
 
     @Override

--- a/floatwindow/src/main/java/com/yhao/floatwindow/MoveType.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/MoveType.java
@@ -1,6 +1,7 @@
 package com.yhao.floatwindow;
 
-import android.support.annotation.IntDef;
+
+import androidx.annotation.IntDef;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/floatwindow/src/main/java/com/yhao/floatwindow/PermissionUtil.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/PermissionUtil.java
@@ -6,9 +6,10 @@ import android.graphics.PixelFormat;
 import android.os.Binder;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.RequiresApi;
 import android.view.View;
 import android.view.WindowManager;
+
+import androidx.annotation.RequiresApi;
 
 import java.lang.reflect.Method;
 

--- a/floatwindow/src/main/java/com/yhao/floatwindow/Screen.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/Screen.java
@@ -1,6 +1,7 @@
 package com.yhao.floatwindow;
 
-import android.support.annotation.IntDef;
+
+import androidx.annotation.IntDef;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/floatwindow/src/main/java/com/yhao/floatwindow/Util.java
+++ b/floatwindow/src/main/java/com/yhao/floatwindow/Util.java
@@ -6,7 +6,6 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.RequiresApi;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;


### PR DESCRIPTION
@yhaolpz FIX：#138 新增 updateFlags 方法，可修复悬浮窗中的edittext无法弹出输入法
```
// 使悬浮窗获取焦点
FloatWindow.get().updateFlags(WindowManager.LayoutParams.FLAG_LAYOUT_INSET_DECOR);
// 使悬浮窗失去焦点
FloatWindow.get().updateFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
```